### PR TITLE
Always pass lib as a third argument to R-install-package

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -18,7 +18,7 @@
     R-install-package
       {{ item.name }}
       {{ item.type | default(r_packages_type) }}
-      {% if item.lib is defined %}{{ item.lib }}{% endif %}
+      {{ item.lib | default(r_packages_lib) }}
       {% if item.repos is defined %}{{ item.repos }}{% endif %}
   register: r_install_package
   changed_when: "r_install_package.stdout_lines[-1] is defined and r_install_package.stdout_lines[-1] == 'changed'"


### PR DESCRIPTION
installing package from specific `repos`
```
r_packages:
   - name: shiny
     repos: http://cran.rstudio.com/
```
crashes with error
```
failed: [52.207.60.105] (item={u'repos': u'http://cran.rstudio.com/', u'name': u'shiny'}) => {
    "changed": false, 
    "cmd": [
        "R-install-package", 
        "shiny", 
        "cran", 
        "http://cran.rstudio.com/"
    ], 
    "delta": "0:00:00.097902", 
    "end": "2017-06-09 07:58:44.351261", 
    "failed": true, 
    "invocation": {
        "module_args": {
            "_raw_params": "R-install-package\n shiny\n cran\n  http://cran.rstudio.com/", 
            "_uses_shell": false, 
            "chdir": null, 
            "creates": null, 
            "executable": null, 
            "removes": null, 
            "warn": true
        }
    }, 
    "item": {
        "name": "shiny", 
        "repos": "http://cran.rstudio.com/"
    }, 
    "rc": 1, 
    "start": "2017-06-09 07:58:44.253359", 
    "stderr": "Error in install.packages(package, lib, repos) : \n  'lib = \"http://cran.rstudio.com/\"' is not writable\nCalls: withCallingHandlers -> install.packages\nExecution halted", 
    "stderr_lines": [
        "Error in install.packages(package, lib, repos) : ", 
        "  'lib = \"http://cran.rstudio.com/\"' is not writable", 
        "Calls: withCallingHandlers -> install.packages", 
        "Execution halted"
    ], 
    "stdout": "", 
    "stdout_lines": []
}
```
because `R-install-package` expects that lib is a third argument.