### PR TITLE
Install GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Set up the latest version of R in Ubuntu systems.
 
 * `r_packages_lib`: [default: `/usr/local/lib/R/site-library`]: The (default) library directory to install packages to
 * `r_packages_repos`: [default: `"{{ r_cran_mirror }}"`]: The (default) URL to install packages from
+* `r_packages_install_remotes`: [default: `false`]: Install the `remotes` package used for installing packages from GitHub
 
 * `r_packages`: [default: `[]`]: (CRAN) Packages to install or remove
 * `r_packages.{n}.name`: [required]: The name of the package
@@ -53,11 +54,13 @@ None
     # apt packages
     r_install:
       - r-recommended
-    # cran or bioconductor (R) packages
+    # cran, bioconductor or github (R) packages
     r_packages:
       - name: dplyr
       - name: Biobase
         type: bioconductor
+      - name: mangothecat/franc
+        type: github
 ```
 
 #### License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,4 +10,5 @@ r_install:
 r_packages_type: cran
 r_packages_repos: "{{ r_cran_mirror }}"
 r_packages_lib: /usr/local/lib/R/site-library
+r_packages_install_remotes: false
 r_packages: []

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -22,7 +22,7 @@
       {% if item.repos is defined %}{{ item.repos }}{% endif %}
   register: r_install_package
   changed_when: "r_install_package.stdout_lines[-1] is defined and r_install_package.stdout_lines[-1] == 'changed'"
-  with_items: "{{ r_packages }}"
+  with_items: "{{ ( [{ 'name' : 'remotes' }] if r_packages_install_remotes == true else [] ) + r_packages }}"
   when: item.state is undefined or item.state == 'present'
   tags:
     - r-packages-install

--- a/templates/usr/local/bin/R-install-package.j2
+++ b/templates/usr/local/bin/R-install-package.j2
@@ -19,6 +19,11 @@ if (!(package %in% installed.packages(lib.loc = lib)[, 'Package'])) {
       source('{{ r_bioclite_url }}')
       biocLite(package, lib = lib, suppressUpdates = TRUE, suppressAutoUpdate = TRUE, ask = FALSE)
     }, warning = stop);
+  } else if (type == 'github') {
+    withCallingHandlers({
+      library(remotes)
+      install_github(package, lib = lib)
+    }, warning = stop);
   } else {
     cat("Unrecognised type\n");
     q(status = 1);

--- a/templates/usr/local/bin/R-install-package.j2
+++ b/templates/usr/local/bin/R-install-package.j2
@@ -6,9 +6,15 @@ if (is.null(argv) | length(argv) < 1) {
   q(status = 1);
 }
 
-package = argv[1];
 type = ifelse(is.na(argv[2]), '{{ r_packages_type }}', argv[2]);
 lib = ifelse(is.na(argv[3]), '{{ r_packages_lib }}', argv[3]);
+
+if (type == 'github') {
+  repo = argv[1];
+  package = unlist(strsplit(repo, "/"))[2];
+} else {
+  package = argv[1];
+}
 
 if (!(package %in% installed.packages(lib.loc = lib)[, 'Package'])) {
   if (type == 'cran') {
@@ -22,7 +28,7 @@ if (!(package %in% installed.packages(lib.loc = lib)[, 'Package'])) {
   } else if (type == 'github') {
     withCallingHandlers({
       library(remotes)
-      install_github(package, lib = lib)
+      install_github(repo, lib = lib)
     }, warning = stop);
   } else {
     cat("Unrecognised type\n");

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -24,3 +24,8 @@
 
       - name: shiny
         repos: http://cran.rstudio.com/
+
+      - name: mangothecat/franc
+        type: github
+
+    r_packages_install_remotes: true


### PR DESCRIPTION
Proposed extension to allow packages whose code is hosted on GitHub to be installed through the playbook. My attempt at the proposed enhancement #16 

Caveat: I tested the PR locally using your included Vagrantfile and everything checks out on 14.04 and 16.04. However 12.04 seems to have some issues with downloading the packages using `remotes::install_github`.