### PR TITLE
Allow R4 install + add warning about r_version_35

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Set up the latest version of R in Ubuntu systems.
 
 #### Variables
 
-* `r_version_35`: [default: `false`, for `Ubuntu >= 18.04` always `true`]: Whether or not to install R 3.5+
+* `r_version_35`: [default: `false`, for `Ubuntu >= 18.04` always `true`]: Whether or not to install R 3.5+ (obsolete, will be removed in future release)
+* `r_version`: [default: `34`, for `Ubuntu >= 18.04` is is set to `35`]: Can be set to 40 for R 4
 
 * `r_cran_mirror`: [default: `https://cran.rstudio.com/`]: Your favorite [CRAN mirror](https://cran.r-project.org/mirrors.html)
 * `r_bioclite_url`: [default: `https://bioconductor.org/biocLite.R`]: The `biocLite.R` script URL for [Bioconductor](https://bioconductor.org/) installs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 # defaults file for r
 ---
 r_version_35: "{{ (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('18.04', '>=')) }}"
+r_version: "{{ '35' if r_version_35 else '34' }}"
 
 r_cran_mirror: https://cran.rstudio.com/
 r_bioclite_url: https://bioconductor.org/biocLite.R

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,10 @@
 # tasks file for r
 ---
+- name: Check r_version_35
+  debug:
+    msg: "[WARNING] r_version_35 variable is obsolete, you should use r_version now"
+  when: r_version_35 is defined
+
 - include: repository.yml
   tags:
     - configuration

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,10 @@
 # vars file for r
 ---
+r_repo_suffix: "{{ '-cran35' if r_version == '35' else '-cran40' if r_version == '40' else '' }}"
+
 r_repository:
   - type: deb
-    url: "{{ r_cran_mirror }}/bin/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }}{{ r_version_35 | ternary('-cran35', '') }}/"
+    url: "{{ r_cran_mirror }}/bin/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }}{{ r_repo_suffix }}/"
 
 r_dependencies_pre:
   - apt-transport-https


### PR DESCRIPTION
Add R 4 install from cran repository.

I also added a warning about r_version_35 which should not be used anymore if we have 3 distinct version of R to install 
from the ubuntu cran repository.

Note that if you set r_version to '40', it mean you're on a recent ubuntu and so you will have r_version_35 auto setted to true, so the other check of this variable will still work.

Maybe we should set the default version to 35 now, as nobody use the 34 anymore, you can check here https://cran.r-project.org/bin/linux/ubuntu/README.html and see that it is only available on very old ubuntu.


